### PR TITLE
feat: restrict signup/unregister to teachers with basic auth

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+[
+  {"username": "teacher1", "password": "pass123"},
+  {"username": "teacher2", "password": "pass456"}
+]


### PR DESCRIPTION
Se implementa el modo administrador: solo los profesores autenticados pueden registrar o desregistrar estudiantes en actividades. Los estudiantes solo pueden visualizar la lista.